### PR TITLE
add bitcoinkernel-covenants crate and tests to support OP_CAT, OP_CSFS and OP_CTV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,17 +14,19 @@ rust-version = "1.85.0"
 [features]
 default = ["std"]
 std = ["bitcoin/std"]
-bitcoinkernel = ["dep:bitcoinkernel"]
+bitcoinkernel-covenants = ["dep:bitcoinkernel-covenants"]
 compiler = []
 trace = []
 
 [dependencies]
-bitcoin = "0.32.5"
+bitcoin = "0.32.7"
 bitcoin-units = "0.1.2"
-bitcoinkernel = { version = "0.0.22", optional = true }
+bitcoinkernel-covenants = { version = "0.0.22", optional = true }
+
 hmac = "0.12.1"
 num-bigint = "0.4.6"
 sha2 = "0.10.9"
 
 [dev-dependencies]
-bitcoinkernel = "0.0.22"
+bitcoinkernel-covenants = "0.0.22"
+

--- a/README.md
+++ b/README.md
@@ -129,12 +129,12 @@ fn generate_address(
 ```
 
 ## Testing
-The default `Verifier` implementation is based on `bitcoinkernel`, which is an optional feature but required to run the included tests.
+The default `Verifier` implementation is based on `bitcoinkernel-covenants`, which is an optional feature but required to run the included tests.
 
 Use the following command to run the test suite:
 
 ```bash
-cargo test --features bitcoinkernel
+cargo test --features bitcoinkernel-covenants
 ```
 
 Or run:


### PR DESCRIPTION
This PR changes the default verifier to use the bitcoinkernel-covenants crate located here https://github.com/stutxo/rust-bitcoinkernel-covenants/tree/covenants_enabled. it is based off of v0.0.22 of bitcoinkernel

It uses a fork of bitcoin here https://github.com/stutxo/bitcoin/tree/kernelApi_48 which enables various covenant op_codes.

For now these are the op_codes supported

- OP_CAT (BIP347)
- OP_CHECKSIGFROMSTACK (BIP348)
- OP_CHECKTEMPLATEVERIFY (BIP119)



