### PR TITLE
feat: Add tx weight to Verifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ pub trait Verifier {
     /// * `input_index` - The index of the input to verify.
     /// * `flags` - Script verification flags.
     /// * `spent_outputs` - The outputs being spent by the transaction.
+    /// * `tx_weight` - The weight of the transaction.
     ///
     /// # Errors
     /// Returns `Error` if verification fails.
@@ -62,6 +63,7 @@ pub trait Verifier {
         input_index: u32,
         flags: Option<u32>,
         spent_outputs: &[TxOut],
+        tx_weight: Weight,
     ) -> Result<(), Error>;
 }
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ pub trait Verifier {
     /// * `amount` - The amount of the input being spent.
     /// * `tx_to` - The transaction containing the script.
     /// * `input_index` - The index of the input to verify.
-    /// * `flags` - Script verification flags.
     /// * `spent_outputs` - The outputs being spent by the transaction.
     /// * `tx_weight` - The weight of the transaction.
     ///
@@ -61,7 +60,6 @@ pub trait Verifier {
         amount: Option<i64>,
         tx_to: &[u8],
         input_index: u32,
-        flags: Option<u32>,
         spent_outputs: &[TxOut],
         tx_weight: Weight,
     ) -> Result<(), Error>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,6 @@ pub trait Verifier {
     /// * `amount` - The amount of the input being spent.
     /// * `tx_to` - The transaction containing the script.
     /// * `input_index` - The index of the input to verify.
-    /// * `flags` - Script verification flags.
     /// * `spent_outputs` - The outputs being spent by the transaction.
     /// * `tx_weight` - The weight of the transaction.
     ///
@@ -111,7 +110,6 @@ pub trait Verifier {
         amount: Option<i64>,
         tx_to: &[u8],
         input_index: u32,
-        flags: Option<u32>,
         spent_outputs: &[TxOut],
         tx_weight: Weight,
     ) -> Result<(), Error>;
@@ -129,7 +127,6 @@ impl Verifier for DefaultVerifier {
         amount: Option<i64>,
         tx_to: &[u8],
         input_index: u32,
-        flags: Option<u32>,
         spent_outputs: &[TxOut],
         tx_weight: Weight,
     ) -> Result<(), Error> {
@@ -149,7 +146,7 @@ impl Verifier for DefaultVerifier {
             amount,
             &bitcoinkernel::Transaction::try_from(tx_to)?,
             input_index,
-            flags,
+            None,
             &outputs,
         )?;
 
@@ -251,7 +248,6 @@ pub fn verify_and_sign<V: Verifier>(
         Some(amount),
         emulated_tx_to,
         input_index,
-        None,
         actual_spent_outputs,
         tx.weight(),
     )?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,7 @@ pub trait Verifier {
     /// * `input_index` - The index of the input to verify.
     /// * `flags` - Script verification flags.
     /// * `spent_outputs` - The outputs being spent by the transaction.
-    /// * `tx_weight` - The outputs being spent by the transaction.
+    /// * `tx_weight` - The weight of the transaction.
     ///
     /// # Errors
     /// Returns `Error` if verification fails.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,8 +44,8 @@
 compile_error!("`std` must be enabled");
 
 use bitcoin::{
-    Address, Network, TapNodeHash, TapSighashType, TapTweakHash, Transaction, TxOut, Witness,
-    XOnlyPublicKey,
+    Address, Network, TapNodeHash, TapSighashType, TapTweakHash, Transaction, TxOut, Weight,
+    Witness, XOnlyPublicKey,
     consensus::deserialize,
     hashes::Hash,
     key::Secp256k1,
@@ -85,6 +85,8 @@ pub enum Error {
     InputIndexOutOfBounds,
     /// Unexpected input scriptPubKey
     UnexpectedInput,
+    /// Exceeds maximum allowed weight
+    ExceedsMaxWeight,
 }
 
 /// Trait to abstract the behavior of the bitcoin script verifier, allowing
@@ -99,6 +101,7 @@ pub trait Verifier {
     /// * `input_index` - The index of the input to verify.
     /// * `flags` - Script verification flags.
     /// * `spent_outputs` - The outputs being spent by the transaction.
+    /// * `tx_weight` - The outputs being spent by the transaction.
     ///
     /// # Errors
     /// Returns `Error` if verification fails.
@@ -110,6 +113,7 @@ pub trait Verifier {
         input_index: u32,
         flags: Option<u32>,
         spent_outputs: &[TxOut],
+        tx_weight: Weight,
     ) -> Result<(), Error>;
 }
 
@@ -127,7 +131,12 @@ impl Verifier for DefaultVerifier {
         input_index: u32,
         flags: Option<u32>,
         spent_outputs: &[TxOut],
+        tx_weight: Weight,
     ) -> Result<(), Error> {
+        if tx_weight > Weight::MAX_BLOCK {
+            return Err(Error::ExceedsMaxWeight);
+        }
+
         let mut outputs = Vec::new();
         for txout in spent_outputs {
             let amount = txout.value.to_signed()?.to_sat();
@@ -244,6 +253,7 @@ pub fn verify_and_sign<V: Verifier>(
         input_index,
         None,
         actual_spent_outputs,
+        tx.weight(),
     )?;
 
     // Get annex if it is data-carrying (leading byte is 0x00)
@@ -429,6 +439,9 @@ impl fmt::Display for Error {
             }
             Error::UnexpectedInput => {
                 write!(f, "Unexpected input scriptPubKey")
+            }
+            Error::ExceedsMaxWeight => {
+                write!(f, "Exceeds maximum allowed transaction weight")
             }
         }
     }
@@ -1153,6 +1166,76 @@ mod kernel_tests {
 
         assert!(verify_result.is_ok());
         assert_eq!(actual_tx.input[1].witness.len(), 1);
+    }
+
+    #[test]
+    fn test_exceeds_max_weight() {
+        let secp = Secp256k1::new();
+
+        // 1. Create a dummy internal key
+        let internal_secret = SecretKey::from_slice(&[1u8; 32]).unwrap();
+        let internal_key = UntweakedPublicKey::from(internal_secret.public_key(&secp));
+
+        // 2. Create OP_TRUE script leaf
+        let op_true_script = Script::builder()
+            .push_opcode(bitcoin::opcodes::OP_TRUE)
+            .into_script();
+
+        // 3. Build the taproot tree with single OP_TRUE leaf
+        let taproot_builder = TaprootBuilder::new()
+            .add_leaf(0, op_true_script.clone())
+            .unwrap();
+        let taproot_spend_info = taproot_builder.finalize(&secp, internal_key).unwrap();
+
+        // 4. Get the control block for our OP_TRUE leaf
+        let control_block = taproot_spend_info
+            .control_block(&(op_true_script.clone(), LeafVersion::TapScript))
+            .unwrap();
+
+        // 5. Create the witness stack for script path spending
+        let mut witness = Witness::new();
+        witness.push(op_true_script.as_bytes());
+        witness.push(control_block.serialize());
+
+        // 6. Create an excessively large emulated transaction
+        let mut emulated_tx = create_test_transaction_single_input();
+        emulated_tx.output = vec![
+            TxOut {
+                value: Amount::from_sat(1),
+                script_pubkey: ScriptBuf::new(),
+            };
+            120_000
+        ];
+        emulated_tx.input[0].witness = witness;
+
+        // 7. Create actual child secret
+        let parent_secret = SecretKey::from_slice(&[1u8; 32]).unwrap();
+        let child_secret = derive_child_secret_key(
+            parent_secret,
+            taproot_spend_info.merkle_root().unwrap().to_byte_array(),
+        )
+        .unwrap();
+
+        // 8. Create actual P2TR output
+        let actual_internal_key = XOnlyPublicKey::from(child_secret.public_key(&secp));
+        let actual_address = Address::p2tr(&secp, actual_internal_key, None, Network::Bitcoin);
+        let actual_spent_outputs = [TxOut {
+            value: Amount::from_sat(100_000),
+            script_pubkey: actual_address.script_pubkey(),
+        }];
+
+        // 9. Verify and sign, expecting an error
+        let result = verify_and_sign(
+            &DefaultVerifier,
+            0,
+            &serialize(&emulated_tx),
+            &actual_spent_outputs,
+            &[1u8; 32],
+            parent_secret,
+            None,
+        );
+
+        assert!(matches!(result, Err(Error::ExceedsMaxWeight)));
     }
 }
 


### PR DESCRIPTION
This PR fixes issue #6 by adding the transaction weight to the `Verifier`. The verifier can then optionally check that the transaction weight is below some limit, which is needed to prevent DOS attacks on the enclave, especially if requests into the enclave are encrypted.

The `DefaultVerifier` checks that the transaction weight is less than the max block weight. Applications may prefer a lower weight limit, however, to ensure that transactions validate faster than the worst case Taproot-only block.

In addition, this PR removes the `flag` parameter from the Verifier, which was unnecessary as the Verifier was always called with no flags and clippy was throwing an error for having too many arguments. 

New `Verifier` trait:

```
/// Trait to abstract the behavior of the bitcoin script verifier, allowing
/// users to provide their own verifier.
pub trait Verifier {
    /// Verify a bitcoin script, mirroring the API of `bitcoinkernel::verify`.
    ///
    /// # Arguments
    /// * `script_pubkey` - The script public key to verify.
    /// * `amount` - The amount of the input being spent.
    /// * `tx_to` - The transaction containing the script.
    /// * `input_index` - The index of the input to verify.
    /// * `spent_outputs` - The outputs being spent by the transaction.
    /// * `tx_weight` - The outputs being spent by the transaction.
    ///
    /// # Errors
    /// Returns `Error` if verification fails.
    fn verify(
        &self,
        script_pubkey: &[u8],
        amount: Option<i64>,
        tx_to: &[u8],
        input_index: u32,
        flags: Option<u32>,
        spent_outputs: &[TxOut],
        tx_weight: Weight,
    ) -> Result<(), Error>;
}
```