### PR TITLE
feat(api): multi-input emulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,23 +42,19 @@ Finally, the enclave should be able to expose the master public key, so that use
 /// Trait to abstract the behavior of the bitcoin script verifier, allowing
 /// users to provide their own verifier.
 pub trait Verifier {
-    /// Verify a bitcoin script, mirroring the API of `bitcoinkernel::verify`.
+    /// Verify one or more scripts in a bitcoin transaction.
     ///
     /// # Arguments
-    /// * `script_pubkey` - The script public key to verify.
-    /// * `amount` - The amount of the input being spent.
-    /// * `tx_to` - The transaction containing the script.
-    /// * `input_index` - The index of the input to verify.
+    /// * `script_pubkeys` - The scriptPubKeys to verify (by index).
+    /// * `tx_to` - The transaction with emulated witness data.
     /// * `spent_outputs` - The outputs being spent by the transaction.
     ///
     /// # Errors
     /// Returns `Error` if verification fails.
     fn verify(
         &self,
-        script_pubkey: &[u8],
-        amount: Option<i64>,
+        script_pubkeys: &HashMap<usize, ScriptBuf>,
         tx_to: &[u8],
-        input_index: usize,
         spent_outputs: &[TxOut],
     ) -> Result<(), Error>;
 }
@@ -70,37 +66,42 @@ pub struct DefaultVerifier;
 ### Convert emulated transaction
 
 ```rust
-/// Verifies an emulated Bitcoin script and signs the corresponding transaction.
+/// Verifies emulated Bitcoin script and signs the corresponding transaction.
 ///
-/// This function performs script verification using bitcoinkernel, verifying an
-/// emulated P2TR input. If successful, it derives an XOnlyPublicKey from the
-/// parent key and the emulated merkle root, which is then tweaked with an optional
-/// backup merkle root to derive the actual spent UTXO, which is then key-path signed
-/// with `SIGHASH_DEFAULT`.
+/// This function performs script verification using a Verifier, which verifies one or
+/// more emulated P2TR inputs. If successful, it derives for each emulated input an
+/// XOnlyPublicKey from the parent key and the emulated merkle root, which is then tweaked
+/// with an optional backup merkle root to derive the input's actual spent UTXO. This is
+/// then key-path signed with `SIGHASH_DEFAULT`.
 ///
 /// If the emulated script-path spend includes a data-carrying annex (begins with 0x50
 /// followed by 0x00), the annex is included in the key-path spend. Otherwise, the annex
 /// is dropped.
 ///
+/// Non-emulated inputs are identified by the input type. An emulated input must be a
+/// P2TR script-path spend, with a derived scriptPubKey that does not match that of the
+/// actual spent output.
+///
+/// Each signature uses a unique `aux_rand` by hashing the provided `aux_rand` with the
+/// index of the input, using SHA256.
+///
 /// # Arguments
 /// * `verifier` - The verifier to use for script validation
-/// * `input_index` - Index of the input to verify and sign (0-based)
 /// * `emulated_tx_to` - Serialized transaction to verify and sign
 /// * `actual_spent_outputs` - Actual outputs being spent
 /// * `aux_rand` - Auxiliary random data for signing
 /// * `parent_key` - Parent secret key used to derive child key for signing
-/// * `backup_merkle_root` - Optional merkle root for backup script path spending
+/// * `backup_merkle_roots` - Optional merkle roots for backup script path spending
 ///
 /// # Errors
 /// Returns error if verification fails, key derivation fails, or signing fails
 pub fn verify_and_sign<V: Verifier>(
     verifier: &V,
-    input_index: usize,
     emulated_tx_to: &[u8],
     actual_spent_outputs: &[TxOut],
     aux_rand: &[u8; 32],
     parent_key: SecretKey,
-    backup_merkle_root: Option<TapNodeHash>,
+    backup_merkle_roots: HashMap<usize, TapNodeHash>,
 ) -> Result<Transaction, Error>;
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,8 +44,8 @@
 compile_error!("`std` must be enabled");
 
 use bitcoin::{
-    Address, Network, TapNodeHash, TapSighashType, TapTweakHash, Transaction, TxOut, Witness,
-    XOnlyPublicKey,
+    Address, Network, ScriptBuf, TapNodeHash, TapSighashType, TapTweakHash, Transaction, TxOut,
+    Witness, XOnlyPublicKey,
     consensus::deserialize,
     hashes::Hash,
     key::Secp256k1,
@@ -56,7 +56,8 @@ use bitcoin::{
 };
 use hmac::{Hmac, Mac};
 use num_bigint::BigUint;
-use sha2::Sha512;
+use sha2::{Digest, Sha256, Sha512};
+use std::collections::HashMap;
 use std::fmt;
 #[cfg(feature = "bitcoinkernel")]
 use std::num::TryFromIntError;
@@ -71,8 +72,6 @@ pub enum Error {
     VerificationFailed(String),
     /// Wrapped secp256k1 errors from cryptographic operations
     Secp256k1(secp256k1::Error),
-    /// Input is not a script path spend (missing taproot control block)
-    NotScriptPathSpend,
     /// Invalid control block format or size
     InvalidControlBlock,
     /// Invalid amount
@@ -81,8 +80,8 @@ pub enum Error {
     DeserializationFailed(bitcoin::consensus::encode::Error),
     /// Unable to calculate sighash
     InvalidSighash,
-    /// Input index out of bounds
-    InputIndexOutOfBounds,
+    /// Missing spent outputs
+    MissingSpentOutputs,
     /// Unexpected input scriptPubKey
     UnexpectedInput,
 }
@@ -90,23 +89,19 @@ pub enum Error {
 /// Trait to abstract the behavior of the bitcoin script verifier, allowing
 /// users to provide their own verifier.
 pub trait Verifier {
-    /// Verify a bitcoin script, mirroring the API of `bitcoinkernel::verify`.
+    /// Verify one or more scripts in a bitcoin transaction.
     ///
     /// # Arguments
-    /// * `script_pubkey` - The script public key to verify.
-    /// * `amount` - The amount of the input being spent.
-    /// * `tx_to` - The transaction containing the script.
-    /// * `input_index` - The index of the input to verify.
+    /// * `script_pubkeys` - The scriptPubKeys to verify (by index).
+    /// * `tx_to` - The transaction with emulated witness data.
     /// * `spent_outputs` - The outputs being spent by the transaction.
     ///
     /// # Errors
     /// Returns `Error` if verification fails.
     fn verify(
         &self,
-        script_pubkey: &[u8],
-        amount: Option<i64>,
+        script_pubkeys: &HashMap<usize, ScriptBuf>,
         tx_to: &[u8],
-        input_index: usize,
         spent_outputs: &[TxOut],
     ) -> Result<(), Error>;
 }
@@ -119,181 +114,220 @@ pub struct DefaultVerifier;
 impl Verifier for DefaultVerifier {
     fn verify(
         &self,
-        script_pubkey: &[u8],
-        amount: Option<i64>,
+        script_pubkeys: &HashMap<usize, ScriptBuf>,
         tx_to: &[u8],
-        input_index: usize,
         spent_outputs: &[TxOut],
     ) -> Result<(), Error> {
+        let mut amounts = Vec::new();
         let mut outputs = Vec::new();
         for txout in spent_outputs {
             let amount = txout
                 .value
                 .to_signed()
-                .map_err(Error::InvalidAmount)?
+                .map_err(Error::InvalidAmount)
+                .map_err(|e| Error::VerificationFailed(e.to_string()))?
                 .to_sat();
             let script = bitcoinkernel::ScriptPubkey::try_from(txout.script_pubkey.as_bytes())
                 .map_err(|e| Error::VerificationFailed(e.to_string()))?;
+
+            amounts.push(amount);
             outputs.push(bitcoinkernel::TxOut::new(&script, amount));
         }
-
-        let script_pubkey = &bitcoinkernel::ScriptPubkey::try_from(script_pubkey)
-            .map_err(|e| Error::VerificationFailed(e.to_string()))?;
 
         let tx_to = &bitcoinkernel::Transaction::try_from(tx_to)
             .map_err(|e| Error::VerificationFailed(e.to_string()))?;
 
-        let input_index: u32 = input_index
-            .try_into()
-            .map_err(|e: TryFromIntError| Error::VerificationFailed(e.to_string()))?;
+        for (&i, script_pubkey) in script_pubkeys {
+            let amount = amounts.get(i).cloned();
+            let script_pubkey = &bitcoinkernel::ScriptPubkey::try_from(script_pubkey.as_bytes())
+                .map_err(|e| Error::VerificationFailed(e.to_string()))?;
+            let i: u32 = i
+                .try_into()
+                .map_err(|e: TryFromIntError| Error::VerificationFailed(e.to_string()))?;
 
-        bitcoinkernel::verify(script_pubkey, amount, tx_to, input_index, None, &outputs)
-            .map_err(|e| Error::VerificationFailed(e.to_string()))?;
+            bitcoinkernel::verify(script_pubkey, amount, tx_to, i, None, &outputs)
+                .map_err(|e| Error::VerificationFailed(e.to_string()))?;
+        }
 
         Ok(())
     }
 }
 
-/// Verifies an emulated Bitcoin script and signs the corresponding transaction.
+/// Verifies emulated Bitcoin script and signs the corresponding transaction.
 ///
-/// This function performs script verification using bitcoinkernel, verifying an
-/// emulated P2TR input. If successful, it derives an XOnlyPublicKey from the
-/// parent key and the emulated merkle root, which is then tweaked with an optional
-/// backup merkle root to derive the actual spent UTXO, which is then key-path signed
-/// with `SIGHASH_DEFAULT`.
+/// This function performs script verification using a Verifier, which verifies one or
+/// more emulated P2TR inputs. If successful, it derives for each emulated input an
+/// XOnlyPublicKey from the parent key and the emulated merkle root, which is then tweaked
+/// with an optional backup merkle root to derive the input's actual spent UTXO. This is
+/// then key-path signed with `SIGHASH_DEFAULT`.
 ///
 /// If the emulated script-path spend includes a data-carrying annex (begins with 0x50
 /// followed by 0x00), the annex is included in the key-path spend. Otherwise, the annex
 /// is dropped.
 ///
+/// Non-emulated inputs are identified by the input type. An emulated input must be a
+/// P2TR script-path spend, with a derived scriptPubKey that does not match that of the
+/// actual spent output.
+///
+/// Each signature uses a unique `aux_rand` by hashing the provided `aux_rand` with the
+/// index of the input, using SHA256.
+///
 /// # Arguments
 /// * `verifier` - The verifier to use for script validation
-/// * `input_index` - Index of the input to verify and sign (0-based)
 /// * `emulated_tx_to` - Serialized transaction to verify and sign
 /// * `actual_spent_outputs` - Actual outputs being spent
 /// * `aux_rand` - Auxiliary random data for signing
 /// * `parent_key` - Parent secret key used to derive child key for signing
-/// * `backup_merkle_root` - Optional merkle root for backup script path spending
+/// * `backup_merkle_roots` - Optional merkle roots for backup script path spending
 ///
 /// # Errors
 /// Returns error if verification fails, key derivation fails, or signing fails
 pub fn verify_and_sign<V: Verifier>(
     verifier: &V,
-    input_index: usize,
     emulated_tx_to: &[u8],
     actual_spent_outputs: &[TxOut],
     aux_rand: &[u8; 32],
     parent_key: SecretKey,
-    backup_merkle_root: Option<TapNodeHash>,
+    backup_merkle_roots: HashMap<usize, TapNodeHash>,
 ) -> Result<Transaction, Error> {
     // Must be able to deserialize transaction
     let mut tx: Transaction = deserialize(emulated_tx_to)?;
 
-    // Input index must be in bounds
-    if input_index >= tx.input.len() || input_index >= actual_spent_outputs.len() {
-        return Err(Error::InputIndexOutOfBounds);
+    // The spent script_pubkeys of the emulated inputs
+    let mut emulated_script_pubkeys: HashMap<usize, ScriptBuf> = HashMap::new();
+
+    // The child keys of each emulated input
+    let mut child_keys_by_index: HashMap<usize, SecretKey> = HashMap::new();
+
+    // Check if missing a spent output
+    if actual_spent_outputs.len() < tx.input.len() {
+        return Err(Error::MissingSpentOutputs);
     }
 
-    // Get the input amount
-    let amount = actual_spent_outputs[input_index]
-        .value
-        .to_signed()?
-        .to_sat();
-
-    // Must be script path spend
-    let input = tx.input[input_index].clone();
-    let (Some(control_block), Some(tapleaf)) = (
-        input.witness.taproot_control_block(),
-        input.witness.taproot_leaf_script(),
-    ) else {
-        return Err(Error::NotScriptPathSpend);
-    };
-    let Ok(control_block) = ControlBlock::decode(control_block) else {
-        return Err(Error::NotScriptPathSpend);
-    };
-
-    // Calculate merkle root
-    let mut merkle_root = TapNodeHash::from_script(tapleaf.script, tapleaf.version);
-    for elem in &control_block.merkle_branch {
-        merkle_root = TapNodeHash::from_node_hashes(merkle_root, *elem);
-    }
-
-    // Create emulated script pubkey
+    // Loop through all inputs and update `emulated_script_pubkeys` and `child_keys_by_index`
     let secp = Secp256k1::new();
-    let emulated_address = Address::p2tr(
-        &secp,
-        control_block.internal_key,
-        Some(merkle_root),
-        Network::Bitcoin,
-    );
+    for (i, input) in tx.input.clone().into_iter().enumerate() {
+        // Must be P2TR script-path spend
+        let (Some(true), Some(control_block), Some(tapleaf)) = (
+            actual_spent_outputs[i]
+                .script_pubkey
+                .is_p2tr()
+                .then_some(true),
+            input.witness.taproot_control_block(),
+            input.witness.taproot_leaf_script(),
+        ) else {
+            continue;
+        };
 
-    // Get actual internal key and child key to be tweaked for signing
-    let child_key = derive_child_secret_key(parent_key, merkle_root.to_byte_array())?;
-    let (internal_key, parity) = child_key.public_key(&secp).x_only_public_key();
-    let child_key_for_tweak = if parity == secp256k1::Parity::Odd {
-        child_key.negate()
-    } else {
-        child_key
-    };
+        // Must be valid control block
+        let Ok(control_block) = ControlBlock::decode(control_block) else {
+            return Err(Error::InvalidControlBlock);
+        };
 
-    // Actual input scriptPubKey must match expected actual scriptPubKey
-    let actual_address = Address::p2tr(&secp, internal_key, backup_merkle_root, Network::Bitcoin);
-    if actual_spent_outputs[input_index].script_pubkey != actual_address.script_pubkey() {
-        return Err(Error::UnexpectedInput);
+        // Calculate merkle root
+        let mut merkle_root = TapNodeHash::from_script(tapleaf.script, tapleaf.version);
+        for elem in &control_block.merkle_branch {
+            merkle_root = TapNodeHash::from_node_hashes(merkle_root, *elem);
+        }
+
+        // Create emulated script pubkey
+        let emulated_address = Address::p2tr(
+            &secp,
+            control_block.internal_key,
+            Some(merkle_root),
+            Network::Bitcoin,
+        );
+
+        // Non-emulated input if actual scriptPubKey matches emulated scriptPubKey
+        if actual_spent_outputs[i].script_pubkey == emulated_address.script_pubkey() {
+            continue;
+        }
+
+        // Get actual internal key and child key to be tweaked for signing
+        let child_key = derive_child_secret_key(parent_key, merkle_root.to_byte_array())?;
+        let (internal_key, _) = child_key.public_key(&secp).x_only_public_key();
+        child_keys_by_index.insert(i, child_key);
+
+        // Actual input scriptPubKey must match expected actual scriptPubKey
+        let backup_merkle_root = backup_merkle_roots.get(&i).cloned();
+        let actual_address =
+            Address::p2tr(&secp, internal_key, backup_merkle_root, Network::Bitcoin);
+        if actual_spent_outputs[i].script_pubkey != actual_address.script_pubkey() {
+            return Err(Error::UnexpectedInput);
+        }
+
+        // Add emulated spent script_pubkey
+        emulated_script_pubkeys.insert(i, emulated_address.script_pubkey());
     }
 
     // Must satisfy verifier
     verifier.verify(
-        emulated_address.script_pubkey().as_bytes(),
-        Some(amount),
+        &emulated_script_pubkeys,
         emulated_tx_to,
-        input_index,
         actual_spent_outputs,
     )?;
 
-    // Get annex if it is data-carrying (leading byte is 0x00)
-    let annex = input
-        .witness
-        .taproot_annex()
-        .filter(|bytes| bytes.len() > 1 && bytes[1] == TAPROOT_ANNEX_DATA_CARRYING_TAG)
-        .and_then(|bytes| Annex::new(bytes).ok());
+    for &i in emulated_script_pubkeys.keys() {
+        // Get annex if it is data-carrying (leading byte is 0x00)
+        let annex = tx.input[i]
+            .witness
+            .taproot_annex()
+            .filter(|bytes| bytes.len() > 1 && bytes[1] == TAPROOT_ANNEX_DATA_CARRYING_TAG)
+            .and_then(|bytes| Annex::new(bytes).ok());
 
-    // Create sighash for the input
-    let mut sighash_cache = SighashCache::new(&tx);
-    let sighash_bytes = sighash_cache
-        .taproot_signature_hash(
-            input_index,
-            &Prevouts::All(actual_spent_outputs),
-            annex.clone(),
-            None,
-            TapSighashType::Default,
-        )
-        .map_err(|_| Error::InvalidSighash)?;
-    let mut sighash = [0u8; 32];
-    sighash.copy_from_slice(sighash_bytes.as_byte_array());
+        // Create sighash for the input
+        let mut sighash_cache = SighashCache::new(&tx);
+        let sighash_bytes = sighash_cache
+            .taproot_signature_hash(
+                i,
+                &Prevouts::All(actual_spent_outputs),
+                annex.clone(),
+                None,
+                TapSighashType::Default,
+            )
+            .map_err(|_| Error::InvalidSighash)?;
+        let mut sighash = [0u8; 32];
+        sighash.copy_from_slice(sighash_bytes.as_byte_array());
 
-    // Calculate the taproot tweaked private key for keypath spending
-    let tweak = TapTweakHash::from_key_and_tweak(internal_key, backup_merkle_root);
-    let tweaked_secret_key = child_key_for_tweak.add_tweak(&tweak.to_scalar())?;
-    let tweaked_keypair = Keypair::from_secret_key(&secp, &tweaked_secret_key);
+        // Lookup child key and prepare for tweak
+        let child_key = child_keys_by_index.get(&i).unwrap();
+        let (internal_key, parity) = child_key.public_key(&secp).x_only_public_key();
+        let child_key_for_tweak = if parity == secp256k1::Parity::Odd {
+            child_key.negate()
+        } else {
+            *child_key
+        };
 
-    // Sign the sighash
-    let message = Message::from_digest(sighash);
-    let signature = secp.sign_schnorr_with_aux_rand(&message, &tweaked_keypair, aux_rand);
+        // Calculate the taproot tweaked private key for keypath spending
+        let backup_merkle_root = backup_merkle_roots.get(&i).cloned();
+        let tweak = TapTweakHash::from_key_and_tweak(internal_key, backup_merkle_root);
+        let tweaked_secret_key = child_key_for_tweak.add_tweak(&tweak.to_scalar())?;
+        let tweaked_keypair = Keypair::from_secret_key(&secp, &tweaked_secret_key);
 
-    // Create taproot signature (schnorr signature + sighash type)
-    let tap_signature = Signature {
-        signature,
-        sighash_type: TapSighashType::Default,
-    };
+        // Hash the original aux_rand with the index to create a unique aux_rand
+        let mut hasher = Sha256::new();
+        hasher.update(aux_rand);
+        hasher.update((i as u64).to_le_bytes());
+        let aux_rand: [u8; 32] = hasher.finalize().into();
 
-    // Create witness for keypath spend (include annex if data-carrying annex is present)
-    let mut witness = Witness::new();
-    witness.push(tap_signature.to_vec());
-    if let Some(annex) = annex {
-        witness.push(annex.as_bytes());
+        // Sign the sighash
+        let message = Message::from_digest(sighash);
+        let signature = secp.sign_schnorr_with_aux_rand(&message, &tweaked_keypair, &aux_rand);
+
+        // Create taproot signature (schnorr signature + sighash type)
+        let tap_signature = Signature {
+            signature,
+            sighash_type: TapSighashType::Default,
+        };
+
+        // Create witness for keypath spend (include annex if data-carrying annex is present)
+        let mut witness = Witness::new();
+        witness.push(tap_signature.to_vec());
+        if let Some(annex) = annex {
+            witness.push(annex.as_bytes());
+        }
+        tx.input[i].witness = witness;
     }
-    tx.input[input_index].witness = witness;
 
     Ok(tx)
 }
@@ -411,12 +445,6 @@ impl fmt::Display for Error {
             Error::Secp256k1(e) => {
                 write!(f, "Secp256k1 cryptographic operation failed: {e}")
             }
-            Error::NotScriptPathSpend => {
-                write!(
-                    f,
-                    "Input is not a script path spend (missing taproot control block)"
-                )
-            }
             Error::InvalidAmount(e) => {
                 write!(f, "Invalid amount: {e}")
             }
@@ -429,8 +457,8 @@ impl fmt::Display for Error {
             Error::InvalidSighash => {
                 write!(f, "Unable to calculate sighash for input")
             }
-            Error::InputIndexOutOfBounds => {
-                write!(f, "Input index out of bounds")
+            Error::MissingSpentOutputs => {
+                write!(f, "Missing spent outputs")
             }
             Error::UnexpectedInput => {
                 write!(f, "Unexpected input scriptPubKey")
@@ -516,65 +544,28 @@ mod kernel_tests {
     fn test_unable_to_deserialize_tx() {
         let result = verify_and_sign(
             &DefaultVerifier,
-            0,
             &[],
             &[],
             &[1u8; 32],
             SecretKey::from_slice(&[1u8; 32]).unwrap(),
-            None,
+            HashMap::new(),
         );
 
         assert!(matches!(result, Err(Error::DeserializationFailed(_))));
     }
 
     #[test]
-    fn test_input_index_out_of_bounds() {
-        let txout = TxOut {
-            value: Amount::from_sat(100000),
-            script_pubkey: ScriptBuf::new_op_return([]),
-        };
+    fn test_missing_spent_outputs() {
         let result = verify_and_sign(
             &DefaultVerifier,
-            1,
-            &serialize(&create_test_transaction_single_input()),
-            std::slice::from_ref(&txout),
-            &[1u8; 32],
-            SecretKey::from_slice(&[1u8; 32]).unwrap(),
-            None,
-        );
-
-        assert!(matches!(result, Err(Error::InputIndexOutOfBounds)));
-
-        let result = verify_and_sign(
-            &DefaultVerifier,
-            0,
             &serialize(&create_test_transaction_single_input()),
             &[],
             &[1u8; 32],
             SecretKey::from_slice(&[1u8; 32]).unwrap(),
-            None,
+            HashMap::new(),
         );
 
-        assert!(matches!(result, Err(Error::InputIndexOutOfBounds)));
-    }
-
-    #[test]
-    fn test_not_script_path_spend() {
-        let txout = TxOut {
-            value: Amount::from_sat(100000),
-            script_pubkey: ScriptBuf::new_op_return([]),
-        };
-        let result = verify_and_sign(
-            &DefaultVerifier,
-            0,
-            &serialize(&create_test_transaction_single_input()),
-            std::slice::from_ref(&txout),
-            &[1u8; 32],
-            SecretKey::from_slice(&[1u8; 32]).unwrap(),
-            None,
-        );
-
-        assert!(matches!(result, Err(Error::NotScriptPathSpend)));
+        assert!(matches!(result, Err(Error::MissingSpentOutputs)));
     }
 
     #[test]
@@ -611,19 +602,19 @@ mod kernel_tests {
         emulated_tx.input[0].witness = witness;
 
         // 7. Create input UTXO with unexpected scriptPubKey
+        let dummy_p2tr_address = Address::p2tr(&secp, internal_key, None, Network::Bitcoin);
         let txout = TxOut {
             value: Amount::from_sat(100000),
-            script_pubkey: ScriptBuf::new_op_return([]),
+            script_pubkey: dummy_p2tr_address.script_pubkey(),
         };
 
         let result = verify_and_sign(
             &DefaultVerifier,
-            0,
             &serialize(&emulated_tx),
             std::slice::from_ref(&txout),
             &[1u8; 32],
             SecretKey::from_slice(&[1u8; 32]).unwrap(),
-            None,
+            HashMap::new(),
         );
 
         assert!(matches!(result, Err(Error::UnexpectedInput)));
@@ -682,12 +673,11 @@ mod kernel_tests {
         // 9. Verify and sign actual transaction
         let actual_tx = verify_and_sign(
             &DefaultVerifier,
-            0,
             &serialize(&emulated_tx),
             &actual_spent_outputs,
             &aux_rand,
             parent_secret,
-            None,
+            HashMap::new(),
         )
         .unwrap();
 
@@ -772,12 +762,11 @@ mod kernel_tests {
         // 9. Verify and sign actual transaction
         let actual_tx = verify_and_sign(
             &DefaultVerifier,
-            0,
             &serialize(&emulated_tx),
             &actual_spent_outputs,
             &aux_rand,
             parent_secret,
-            None,
+            HashMap::new(),
         )
         .unwrap();
 
@@ -863,12 +852,11 @@ mod kernel_tests {
         // 9. Verify and sign actual transaction
         let actual_tx = verify_and_sign(
             &DefaultVerifier,
-            0,
             &serialize(&emulated_tx),
             &actual_spent_outputs,
             &aux_rand,
             parent_secret,
-            actual_backup_merkle_root,
+            HashMap::from([(0, actual_backup_merkle_root.unwrap())]),
         )
         .unwrap();
 
@@ -952,12 +940,11 @@ mod kernel_tests {
         // 10. Verify and sign actual transaction
         let actual_tx = verify_and_sign(
             &DefaultVerifier,
-            0,
             &serialize(&emulated_tx),
             &actual_spent_outputs,
             &aux_rand,
             parent_secret,
-            None,
+            HashMap::new(),
         )
         .unwrap();
 
@@ -1042,12 +1029,11 @@ mod kernel_tests {
         // 10. Verify and sign actual transaction
         let actual_tx = verify_and_sign(
             &DefaultVerifier,
-            0,
             &serialize(&emulated_tx),
             &actual_spent_outputs,
             &aux_rand,
             parent_secret,
-            None,
+            HashMap::new(),
         )
         .unwrap();
 
@@ -1133,12 +1119,11 @@ mod kernel_tests {
         // 9. Verify and sign actual transaction
         let actual_tx = verify_and_sign(
             &DefaultVerifier,
-            1,
             &serialize(&emulated_tx),
             &actual_spent_outputs,
             &aux_rand,
             parent_secret,
-            None,
+            HashMap::new(),
         )
         .unwrap();
 


### PR DESCRIPTION
_This PR is a replacement for PR #12, adding support for multiple different backup merkle roots and uniquely derived `aux_rand` for each signature, using a hash of the provided `aux_rand` and the index of the input. It also simplifies the `Verifier` API by removing the need for a set of inputs to skip._

This PR addresses issue #8 , by modifying the API to support multi-input emulation.

This change is necessary to avoid quadratic deserialization. Previously, each emulated input required a separate API call. This is problematic because the `Verifier` cannot accept a deserialized transaction type, as the transaction model used by the verifier is unspecified. As a result, the `Verifier` must deserialize the transaction each API call, risking prohibitively expensive quadratic deserialization in transactions with many emulated inputs.

One solution is to pass in two transaction types, one with a known bitcoin transaction type and one with an unknown type, used by the verifier. This would require though additional work by the consumer of the API and is needlessly complicated.

This PR instead resolves the problem by calling the `verify` API only once across the entire transaction. Non-emulated inputs are made explicit to the `Verifier` so they can be skipped, avoiding unnecessary work while still making it possible to use the API on partially-signed transactions.

The `verify_and_sign` API does not require explicit identification of emulated inputs. Instead, we infer emulated inputs by looking at the input type. Emulated inputs must have a P2TR `script_pubkey` in the actual spent UTXO, must be a script-path spend, and must have a witness that implies a spent `script_pubkey` that differs from that of the actual UTXO. If these conditions are not met, the input is considered to be non-emulated.

New API:
```rust
/// Trait to abstract the behavior of the bitcoin script verifier, allowing
/// users to provide their own verifier.
pub trait Verifier {
    /// Verify one or more scripts in a bitcoin transaction.
    ///
    /// # Arguments
    /// * `script_pubkeys` - The scriptPubKeys to verify (by index).
    /// * `tx_to` - The transaction with emulated witness data.
    /// * `spent_outputs` - The outputs being spent by the transaction.
    ///
    /// # Errors
    /// Returns `Error` if verification fails.
    fn verify(
        &self,
        script_pubkeys: &HashMap<usize, ScriptBuf>,
        tx_to: &[u8],
        spent_outputs: &[TxOut],
    ) -> Result<(), Error>;
}

/// The default `Verifier` implementation that uses `bitcoinkernel`.
pub struct DefaultVerifier;
```

```rust
/// Verifies emulated Bitcoin script and signs the corresponding transaction.
///
/// This function performs script verification using a Verifier, which verifies one or
/// more emulated P2TR inputs. If successful, it derives for each emulated input an
/// XOnlyPublicKey from the parent key and the emulated merkle root, which is then tweaked
/// with an optional backup merkle root to derive the input's actual spent UTXO. This is
/// then key-path signed with `SIGHASH_DEFAULT`.
///
/// If the emulated script-path spend includes a data-carrying annex (begins with 0x50
/// followed by 0x00), the annex is included in the key-path spend. Otherwise, the annex
/// is dropped.
///
/// Non-emulated inputs are identified by the input type. An emulated input must be a
/// P2TR script-path spend, with a derived scriptPubKey that does not match that of the
/// actual spent output.
///
/// Each signature uses a unique `aux_rand`, by hashing the provided `aux_rand` with the
/// index of the input, using SHA256.
///
/// # Arguments
/// * `verifier` - The verifier to use for script validation
/// * `emulated_tx_to` - Serialized transaction to verify and sign
/// * `actual_spent_outputs` - Actual outputs being spent
/// * `aux_rand` - Auxiliary random data for signing
/// * `parent_key` - Parent secret key used to derive child key for signing
/// * `backup_merkle_roots` - Optional merkle roots for backup script path spending
///
/// # Errors
/// Returns error if verification fails, key derivation fails, or signing fails
pub fn verify_and_sign<V: Verifier>(
    verifier: &V,
    emulated_tx_to: &[u8],
    actual_spent_outputs: &[TxOut],
    aux_rand: &[u8; 32],
    parent_key: SecretKey,
    backup_merkle_roots: HashMap<usize, TapNodeHash>,
) -> Result<Transaction, Error>;
```