### PR TITLE
feat(api): externalize deserialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ pub trait Verifier {
     fn verify(
         &self,
         script_pubkeys: &HashMap<usize, ScriptBuf>,
-        tx_to: &[u8],
+        tx_to: &Transaction,
         spent_outputs: &[TxOut],
     ) -> Result<(), Error>;
 }
@@ -87,7 +87,7 @@ pub struct DefaultVerifier;
 ///
 /// # Arguments
 /// * `verifier` - The verifier to use for script validation
-/// * `emulated_tx_to` - Serialized transaction to verify and sign
+/// * `emulated_tx_to` - Emulated transaction to verify and sign
 /// * `actual_spent_outputs` - Actual outputs being spent
 /// * `aux_rand` - Auxiliary random data for signing
 /// * `parent_key` - Parent secret key used to derive child key for signing
@@ -97,7 +97,7 @@ pub struct DefaultVerifier;
 /// Returns error if verification fails, key derivation fails, or signing fails
 pub fn verify_and_sign<V: Verifier>(
     verifier: &V,
-    emulated_tx_to: &[u8],
+    emulated_tx_to: &Transaction,
     actual_spent_outputs: &[TxOut],
     aux_rand: &[u8; 32],
     parent_key: SecretKey,


### PR DESCRIPTION
This PR externalizes deserialization. This is appropriate because the consumer of the API may want to use the `Transaction` type in the request payload struct, so they can benefit from the built-in deserialization.

Currently, doing so requires the consumer to needlessly serialize the transaction to use the library, just for the library to deserialize it again. Now, the library performs no deserializations, and only the `Verifier` may need to serialize the transaction, to pass it to the kernel.

As deserialization is no longer necessary, the `DeserializationFailed` error type has been removed.